### PR TITLE
context.WithTimeout の cancel を無視しない

### DIFF
--- a/server.go
+++ b/server.go
@@ -376,7 +376,8 @@ func main() {
 
 		log.Info().Msg("Starting server shutdown")
 
-		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		if err := server.Shutdown(ctx); err != nil {
 			// Error from closing listeners, or context timeout:
 			log.Error().Err(err).Msgf("HTTP server Shutdown: %v", err)


### PR DESCRIPTION
lostcancel: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak (govet)