### PR TITLE
format 指定なしの Fprintf を Fprint に変更

### DIFF
--- a/server.go
+++ b/server.go
@@ -252,7 +252,7 @@ func innerHandler(w http.ResponseWriter, r *http.Request, requestId string) int 
 		}
 
 		s, _ := json.Marshal(j)
-		fmt.Fprintf(w, string(s))
+		fmt.Fprint(w, string(s))
 	} else {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(response_code)


### PR DESCRIPTION
SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)