### PR TITLE
fix: ログフィールド名のタイポを修正 (pharse -> phase)

### DIFF
--- a/server.go
+++ b/server.go
@@ -123,7 +123,7 @@ func preProcessLog(r *http.Request, requestId string) {
 		Str("remoteIp", r.RemoteAddr).
 		Int64("requestSize", r.ContentLength).
 		Str("userAgent", r.Header.Get("User-Agent"))).
-		Str("pharse", "pre").
+		Str("phase","pre").
 		Str("requestId", requestId).
 		Msg("")
 }
@@ -137,7 +137,7 @@ func postProcessLog(r *http.Request, requestId string, status int, duration time
 		Str("userAgent", r.Header.Get("User-Agent")).
 		Int("status", status).
 		Str("latency", fmt.Sprintf("%.3fs", float64(duration.Milliseconds())/1000))).
-		Str("pharse", "post").
+		Str("phase","post").
 		Str("requestId", requestId).
 		Msg("")
 }


### PR DESCRIPTION
## 概要

`preProcessLog` と `postProcessLog` のログフィールド名 `"pharse"` を `"phase"` に修正しました。

## 変更箇所

- `server.go:126` — `Str("pharse", "pre")` → `Str("phase", "pre")`
- `server.go:140` — `Str("pharse", "post")` → `Str("phase", "post")`

> **注意**: このフィールド名を参照しているログ監視・クエリがある場合は合わせて更新が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)