### PR TITLE
feat: リクエストボディのサイズ制限を実装

### DIFF
--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -21,12 +22,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const defaultMaxBodySize = 20 * 1024 * 1024 // 20MB
+
 var (
 	version           = "unknown"
 	commit            = "unknown"
 	date              = "unknown"
 	debug             = false
 	sessionCookieName = "SESSION_ID"
+	maxBodySize       int64 = defaultMaxBodySize
 )
 
 var sensitiveEnvKeywords = []string{
@@ -175,8 +179,15 @@ type jsonResponse struct {
 }
 
 func innerHandler(w http.ResponseWriter, r *http.Request, requestId string) int {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 	buf, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			log.Warn().Int64("limit", maxBytesErr.Limit).Str("requestId", requestId).Msg("Request body too large")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return http.StatusRequestEntityTooLarge
+		}
 		log.Error().Err(err).Str("requestId", requestId).Msg("Failed to read request body")
 		w.WriteHeader(http.StatusBadRequest)
 		return http.StatusBadRequest
@@ -403,6 +414,15 @@ func main() {
 	if debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
+
+	if s := os.Getenv("MAX_BODY_SIZE"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil && n > 0 {
+			maxBodySize = n
+		} else {
+			log.Warn().Str("value", s).Msg("Invalid MAX_BODY_SIZE, using default")
+		}
+	}
+	log.Info().Int64("maxBodySize", maxBodySize).Msg("Request body size limit")
 
 	listenPort := getEnv("PORT", "8080")
 	listenAddr := getEnv("LISTEN_ADDR", "0.0.0.0")


### PR DESCRIPTION
## 概要

リクエストボディのサイズ制限を実装しました。

## 変更内容

- デフォルト上限: **20MB**
- 環境変数 `MAX_BODY_SIZE`（バイト単位の整数）で上書き可能
  - 例: `MAX_BODY_SIZE=10485760` で 10MB に変更
  - 無効な値を指定した場合はデフォルト値を使用してログに警告を出力
- 制限超過時は **413 Request Entity Too Large** を返す
- 起動時にサイズ制限値をログ出力

## 実装詳細

`http.MaxBytesReader` で `r.Body` をラップしてから `io.ReadAll` することで制限を適用。  
エラー種別を `*http.MaxBytesError` で判別し、超過の場合と他のエラーで異なるレスポンスを返す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)