### PR TITLE
chore: add minimumReleaseAge of 7 days to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "assignees": ["yteraoka"],
   "extends": [
     "config:base"
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary

- `minimumReleaseAge: "7 days"` を追加し、パッケージのリリースから 7 日経過後に Renovate が PR を作成するよう設定

## Why

リリース直後のパッケージには予期しないバグが含まれる場合があるため、7 日間の待機期間を設けることでより安定したバージョンへの更新を行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)