### PR TITLE
chore: pin aquasecurity/trivy-action to v0.35.0 commit hash

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Trivy
         # https://github.com/aquasecurity/trivy-action
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: test-http-server:scan
           format: table


### PR DESCRIPTION
## Summary

- `aquasecurity/trivy-action@master` を最新タグ v0.35.0 のコミットハッシュで固定
- `aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0`

## Why

`@master` 参照はいつでも変わる可能性があり、予期しない変更が入る恐れがある。コミットハッシュで固定することでサプライチェーン攻撃のリスクを低減し、再現性を高める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)